### PR TITLE
Use fewer runs to correct date

### DIFF
--- a/lib/crontab/scheduler.ex
+++ b/lib/crontab/scheduler.ex
@@ -267,18 +267,16 @@ defmodule Crontab.Scheduler do
   end
 
   defp get_run_date(cron_expression = %CronExpression{extended: false}, date, max_runs, direction) do
-    condition_list =
-      case direction do
-        :increment -> CronExpression.to_condition_list(cron_expression)
-        :decrement -> Enum.reverse(CronExpression.to_condition_list(cron_expression))
-      end
-
-    get_run_date(condition_list, DateHelper.beginning_of(date, :minute), max_runs, direction)
+    cron_expression
+    |> CronExpression.to_condition_list()
+    |> Enum.reverse()
+    |> get_run_date(DateHelper.beginning_of(date, :minute), max_runs, direction)
   end
 
   defp get_run_date(cron_expression = %CronExpression{extended: true}, date, max_runs, direction) do
     cron_expression
     |> CronExpression.to_condition_list()
+    |> Enum.reverse()
     |> get_run_date(DateHelper.beginning_of(date, :second), max_runs, direction)
   end
 

--- a/test/crontab/scheduler_test.exs
+++ b/test/crontab/scheduler_test.exs
@@ -61,4 +61,11 @@ defmodule Crontab.SchedulerTest do
              ~N[2002-01-13 23:00:07]
            ) == {:ok, ~N[2002-02-27 07:03:00]}
   end
+
+  test "check run limits" do
+    assert get_next_run_date(
+             %Crontab.CronExpression{extended: true, second: [59], minute: [59], hour: [23], day: [31], month: [12], year: [9999]},
+             ~N[1234-05-06 07:08:09]
+           ) == {:ok, ~N[9999-12-31 23:59:59]}
+  end
 end


### PR DESCRIPTION
Fix #48 

By matching bigger interval first makes it corrects faster.