### PR TITLE
Fast fail on impossible year scenarios

### DIFF
--- a/lib/crontab/scheduler.ex
+++ b/lib/crontab/scheduler.ex
@@ -284,6 +284,8 @@ defmodule Crontab.Scheduler do
       {:found, corrected_date} ->
         {:ok, corrected_date}
 
+      {:error, :impossible} ->
+        {:error, "No compliant date was found for your interval."}
 
       {:not_found, corrected_date} ->
         get_run_date(conditions, corrected_date, max_runs - 1, direction)
@@ -292,6 +294,25 @@ defmodule Crontab.Scheduler do
 
   @spec search_and_correct_date(CronExpression.condition_list(), NaiveDateTime.t(), direction) ::
           NaiveDateTime.t() | {:not_found, NaiveDateTime.t()}
+
+  defp search_and_correct_date(
+         [{:year, [target_year]} | _],
+         %NaiveDateTime{year: from_year},
+         :increment
+       )
+       when target_year < from_year do
+    {:error, :impossible}
+  end
+
+  defp search_and_correct_date(
+         [{:year, [target_year]} | _],
+         %NaiveDateTime{year: from_year},
+         :decrement
+       )
+       when target_year > from_year do
+    {:error, :impossible}
+  end
+
   defp search_and_correct_date([{interval, conditions} | tail], date, direction) do
     if matches_date?(interval, conditions, date) do
       search_and_correct_date(tail, date, direction)

--- a/lib/crontab/scheduler.ex
+++ b/lib/crontab/scheduler.ex
@@ -300,7 +300,7 @@ defmodule Crontab.Scheduler do
          %NaiveDateTime{year: from_year},
          :increment
        )
-       when target_year < from_year do
+       when is_integer(target_year) and target_year < from_year do
     {:error, :impossible}
   end
 
@@ -309,7 +309,7 @@ defmodule Crontab.Scheduler do
          %NaiveDateTime{year: from_year},
          :decrement
        )
-       when target_year > from_year do
+       when is_integer(target_year) and target_year > from_year do
     {:error, :impossible}
   end
 

--- a/lib/crontab/scheduler.ex
+++ b/lib/crontab/scheduler.ex
@@ -280,11 +280,13 @@ defmodule Crontab.Scheduler do
   end
 
   defp get_run_date(conditions, date, max_runs, direction) do
-    {status, corrected_date} = search_and_correct_date(conditions, date, direction)
+    case search_and_correct_date(conditions, date, direction) do
+      {:found, corrected_date} ->
+        {:ok, corrected_date}
 
-    case status do
-      :found -> {:ok, corrected_date}
-      _ -> get_run_date(conditions, corrected_date, max_runs - 1, direction)
+
+      {:not_found, corrected_date} ->
+        get_run_date(conditions, corrected_date, max_runs - 1, direction)
     end
   end
 


### PR DESCRIPTION
With all other fields other than year, it makes sense to continue iterating in either direction, since the values of everything other than year eventually repeat. With year, however, we can easily end up iterating `@max_runs` in many common scenarios, such as: 

```
 ~e[1 2 3 4 5 * 2010]e |> Crontab.Scheduler.get_next_run_date
```

If done inside a hot loop, this can become a very expensive operation. While we can't totally eliminate these cases, we *can* detect them in the case of simple single-year lookups and fail quickly without having to run out the `@max_runs` clock. If we're iterating (say) forward and we're being asked to match against a (single) year which is strictly before the candidate year, there's no possible way it will ever match. In this case we can return quickly and avoid having to loop `@max_runs` times to come to the same conclusion. A similar logic applies for decrementing searches. 

Note that this *only* applies to single-year targets. Year targets such as `*/5` will continue to be matched (or not) by previous logic.




