### PR TITLE
Fix compilation warnings on Ecto 3.2.0

### DIFF
--- a/lib/crontab/cron_expression/ecto_type.ex
+++ b/lib/crontab/cron_expression/ecto_type.ex
@@ -72,5 +72,9 @@ if Code.ensure_compiled?(Ecto.Type) do
     end
 
     def dump(_), do: :error
+
+    def embed_as(_), do: :self
+
+    def equal?(term1, term2), do: term1 == term2
   end
 end


### PR DESCRIPTION
Ecto 3.2.0 defines two new callbacks for types, they provide default
implementations for them if the type uses `use Ecto.Type` instead of
`@behaviour Ecto.Type`, but this breaks compatibility with anything less
than Ecto 3.2.0, so the default implementations are just hardcoded here.

Closes #62 