### PR TITLE
Bump version to current in getting started pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Parse Cron Format Strings, Write Cron Format Strings and Calculate Execution Dat
 
 ```elixir
 def deps do
-  [{:crontab, "~> 1.1.10"}]
+  [{:crontab, "~> 1.1"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Parse Cron Format Strings, Write Cron Format Strings and Calculate Execution Dat
 
 ```elixir
 def deps do
-  [{:crontab, "~> 1.1.2"}]
+  [{:crontab, "~> 1.1.10"}]
 end
 ```
 

--- a/pages/Getting Started.md
+++ b/pages/Getting Started.md
@@ -5,7 +5,7 @@
 
     ```elixir
     def deps do
-      [{:crontab, "~> 0.8.5"}]
+      [{:crontab, "~> 1.1.10"}]
     end
     ```
 

--- a/pages/Getting Started.md
+++ b/pages/Getting Started.md
@@ -5,7 +5,7 @@
 
     ```elixir
     def deps do
-      [{:crontab, "~> 1.1.10"}]
+      [{:crontab, "~> 1.1"}]
     end
     ```
 


### PR DESCRIPTION
It seems the docs page is slightly behind the published version