### PR TITLE
Do not crash when parsing invalid seconds

### DIFF
--- a/lib/crontab/cron_expression/parser.ex
+++ b/lib/crontab/cron_expression/parser.ex
@@ -31,6 +31,7 @@ defmodule Crontab.CronExpression.Parser do
 
   @extended_intervals [:second | @intervals]
 
+  @second_values 0..59
   @minute_values 0..59
   @hour_values 0..23
   @day_of_month_values 1..31
@@ -233,6 +234,10 @@ defmodule Crontab.CronExpression.Parser do
 
   @spec clean_value(CronExpression.interval(), binary) ::
           {:ok, CronExpression.value()} | {:error, binary}
+
+  defp clean_value(:second, value) do
+    clean_integer_within_range(value, "second", @second_values)
+  end
 
   defp clean_value(:minute, value) do
     clean_integer_within_range(value, "minute", @minute_values)

--- a/test/crontab/cron_expression/parser_test.exs
+++ b/test/crontab/cron_expression/parser_test.exs
@@ -221,6 +221,23 @@ defmodule Crontab.CronExpression.ParserTest do
               }}
   end
 
+  test "parse second followed by string gives error" do
+    assert parse("42invalid * * * *", true) == {:error, "Can't parse 42invalid as second."}
+  end
+
+  test "parse negative second gives error" do
+    assert parse("-1", true) == {:error, "Can't parse -1 as second."}
+  end
+
+  test "parse out of range second gives error" do
+    assert parse("60", true) == {:error, "Can't parse 60 as second."}
+  end
+
+  test "valid seconds do not give error" do
+    assert parse("10", true) == {:ok, ~e[10 * * * * * *]e}
+    assert parse("*/10", true) == {:ok, ~e[*/10 * * * * * *]e}
+  end
+
   test "parse minute followed by string gives error" do
     assert parse("42invalid * * * *") == {:error, "Can't parse 42invalid as minute."}
   end


### PR DESCRIPTION
- Add unit tests for extended parsing checks
- Extracts seconds similarly to minutes