### PR TITLE
tylerpachal-fix-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ iex> import Crontab.CronExpression
 iex> Crontab.Scheduler.get_next_run_date(~e[*/2], ~N[2017-01-01 01:01:00])
 {:ok, ~N[2017-01-01 01:02:00]}
 iex> Crontab.Scheduler.get_next_run_date!(~e[*/2], ~N[2017-01-01 01:01:00])
-{:ok, ~N[2017-01-01 01:02:00]}
+~N[2017-01-01 01:02:00]
 ```
 
 ```elixir


### PR DESCRIPTION
Fixes an example where a `bang!` function was mistakenly returning an `:ok` tuple.

The same error is present in the [Hex documentation](https://hexdocs.pm/crontab/basic-usage.html#find-next-previous-execution-date-candidates) but it looked to me like that documentation was somehow linked to the readme (if it isn't, we'll have to go fix this in an additional spot).