### PR TITLE
Ecto.Type: Switch embed_as to `:dump`

### DIFF
--- a/lib/crontab/cron_expression/ecto_type.ex
+++ b/lib/crontab/cron_expression/ecto_type.ex
@@ -83,7 +83,7 @@ end
 
     def dump(_), do: :error
 
-    def embed_as(_), do: :self
+    def embed_as(_), do: :dump
 
     def equal?(term1, term2), do: term1 == term2
   end


### PR DESCRIPTION
When using the Ecto typ inside of an embedded schema, we get the following error:

```
protocol Jason.Encoder not implemented for ~e[0 12 * * 1 *] of type Crontab.CronExpression (a struct), Jason.Encoder protocol must always be explicitly implemented.
```

This is because by default the type will be embedded as a JSON dump of it's struct (see https://hexdocs.pm/ecto/Ecto.Type.html#c:embed_as/1)

Switching to `:dump` means that when embedding this type in a embedded schema we still call the `dump` callback, and the error goes away.