### PR TITLE
Fix warning caused by usage of deprecated `Application.get_env`

### DIFF
--- a/lib/crontab/cron_expression/ecto_type.ex
+++ b/lib/crontab/cron_expression/ecto_type.ex
@@ -1,14 +1,4 @@
-# TODO: Replace with simple Code.ensure_compiled as soon as Elixir minimum
-# version is raised to 1.10.
-
-Code
-|> function_exported?(:ensure_compiled, 1)
-|> if do
-  match?({:module, Ecto.Type}, Code.ensure_compiled(Ecto.Type))
-else
-  :erlang.apply(Code, :ensure_compiled?, [Ecto.Type])
-end
-|> if do
+if match?({:module, Ecto.Type}, Code.ensure_compiled(Ecto.Type)) do
   defmodule Crontab.CronExpression.Ecto.Type do
     @moduledoc """
     Provides a type for Ecto usage.

--- a/lib/crontab/scheduler.ex
+++ b/lib/crontab/scheduler.ex
@@ -13,13 +13,7 @@ defmodule Crontab.Scheduler do
   @type direction :: :increment | :decrement
   @type result :: maybe(NaiveDateTime.t(), any)
 
-  # TODO: Remove if when requiring Elixir 1.10 + only
-  if function_exported?(Application, :compile_env, 3) do
-    @max_runs Application.compile_env(:crontab, :max_runs, 10_000)
-  else
-    # credo:disable-for-next-line Credo.Check.Warning.ApplicationConfigInModuleAttribute
-    @max_runs Application.get_env(:crontab, :max_runs, 10_000)
-  end
+  @max_runs Application.compile_env(:crontab, :max_runs, 10_000)
 
   @doc """
   This function provides the functionality to retrieve the next run date from a

--- a/test/crontab/cron_expression/ecto_type_test.exs
+++ b/test/crontab/cron_expression/ecto_type_test.exs
@@ -1,12 +1,4 @@
-# TODO: Replace with simple Code.ensure_compiled as soon as Elixir min. version is raised to 1.10
-Code
-|> function_exported?(:ensure_compiled, 1)
-|> if do
-  match?({:module, Ecto.Type}, Code.ensure_compiled(Ecto.Type))
-else
-  :erlang.apply(Code, :ensure_compiled?, [Ecto.Type])
-end
-|> if do
+if match?({:module, Ecto.Type}, Code.ensure_compiled(Ecto.Type)) do
   defmodule Crontab.CronExpression.Ecto.TypeTest do
     @moduledoc false
 


### PR DESCRIPTION
It seems that this should already be fixed, but I think the `function_exported?` check doesn't work for macros.
The minimum version is already Elixir 1.10, so it should be safe to remove the whole check.
